### PR TITLE
Prevent duplicate notes feature

### DIFF
--- a/dash_board.js
+++ b/dash_board.js
@@ -717,17 +717,21 @@ function calculateResult() {
         display.textContent = 'Error';
     }
 }
-
 // Notes Functions
 function saveNote() {
     const noteInput = document.getElementById('notes-input');
     const text = noteInput.value.trim();
+
     if (text) {
+        const existingNotes = document.querySelectorAll('.note');
+        for (let note of existingNotes) {
+            if (note.textContent === text) {
+                alert("Duplicate note not allowed.");
+                return;
+            }
+        }
+
         addNote(text);
         noteInput.value = '';
     }
 }
-
-function clearNote() {
-    document.getElementById('notes-input').value = '';
-} 


### PR DESCRIPTION
To avoid saving the same note more than once, ensuring cleaner data and avoiding redundancy in the notes list.  To keep the interface tidy and avoid repetitive information. In to-do apps, journaling tools, or note managers where uniqueness is preferred.